### PR TITLE
DEV-2017 Accept mam_main_query in custom job

### DIFF
--- a/app/syncrator_api.py
+++ b/app/syncrator_api.py
@@ -207,7 +207,7 @@ def syncrator_dryrun():
 def job_params_from_request():
     try:
         request_data = request.json
-        return {
+        params = {
             'TARGET': request_data['target'],
             'ENV': app.config.get('SYNC_ENV'),  # request_data['env'],
             'ACTION_NAME': request_data['action_name'],
@@ -215,6 +215,12 @@ def job_params_from_request():
             'IS_TAG': request_data['is_tag'],
             'OPTIONS': request_data['options']
         }
+        # Add MAM_MAIN_QUERY if it was filled in.
+        try:
+            params["MAM_MAIN_QUERY"] = request_data['mam_main_query']
+        except:
+            pass
+        return params
     except TypeError:
         abort(400, 'Invalid job parameters')
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -244,6 +244,24 @@ def test_general_job_run(client):
     assert generic_data['TARGET'] == delta_data['TARGET']
     assert generic_data['ACTION'] == delta_data['ACTION']
     assert generic_data['result'] == 'starting'
+    assert generic_data.get('MAM_MAIN_QUERY') is None
+
+
+def test_general_job_run_mam_main_query(client):
+    resp = client.post('/run',
+                       headers={'Authorization': jwt_token()},
+                       json={
+                            'target': 'avo',
+                            'env': 'qas',
+                            'action_name': 'delta',
+                            'action': 'delta',
+                            'is_tag': 'latest',
+                            'options': '-n 1000 -c 1',
+                            'mam_main_query': '+(type:video)'
+                       })
+    assert resp.status_code == status.HTTP_200_OK
+    data = resp.get_json()
+    assert data['MAM_MAIN_QUERY'] == '+(type:video)'
 
 
 def test_dryrun_openshift_commands(client, setup):


### PR DESCRIPTION
It should be possible to pass a value for `mam_main_query` when running a
custom job. That value will be filled in in the job template. This is an
optional value and the key can be omitted.